### PR TITLE
Blacklist masterminds in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 !Cargo.lock
 !migrations
 !entrypoint.sh
+!award_id_blacklist.txt


### PR DESCRIPTION
This file seems to be forgotten when the Docker image was designed. Without this the bot might give "kultainen testauskoira" award to some mastermind.