### PR TITLE
Add a button to voting that does nothing.

### DIFF
--- a/migrations/2022-01-31-181024_useless_button/down.sql
+++ b/migrations/2022-01-31-181024_useless_button/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE CouncilVotings
+DROP COLUMN useless_clicks;

--- a/migrations/2022-01-31-181024_useless_button/up.sql
+++ b/migrations/2022-01-31-181024_useless_button/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE CouncilVotings
+ADD COLUMN useless_clicks BIGINT NOT NULL;

--- a/src/database/voting.rs
+++ b/src/database/voting.rs
@@ -27,6 +27,7 @@ impl Database {
             block_reporter_votes: 0,
             block_reporter_votes_required: (mods_online as f32).sqrt().clamp(1., 3.).round() as i32,
             moderators_online: mods_online,
+            useless_clicks: 0,
         };
         Ok(diesel::insert_into(crate::schema::CouncilVotings::table)
             .values(&new_voting)
@@ -241,5 +242,12 @@ impl Database {
             ),
             _ => Ok(0),
         }
+    }
+
+    pub async fn add_useless_click(&self, message_id: u64) -> Result<usize, anyhow::Error> {
+        use crate::schema::CouncilVotings::dsl::*;
+        Ok(diesel::update(CouncilVotings.filter(vote_message_id.eq(message_id)))
+            .set(useless_clicks.eq(useless_clicks + 1))
+            .execute(&self.pool.get()?)?)
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -33,6 +33,7 @@ pub struct CouncilVoting {
     pub block_reporter_votes: i32,
     pub block_reporter_votes_required: i32,
     pub moderators_online: i32,
+    pub useless_clicks: i64,
 }
 
 use crate::schema::CouncilVotings;
@@ -54,6 +55,7 @@ pub struct NewCouncilVoting {
     pub block_reporter_votes: i32,
     pub block_reporter_votes_required: i32,
     pub moderators_online: i32,
+    pub useless_clicks: i64,
 }
 
 #[derive(Queryable, Clone, Debug)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -17,6 +17,7 @@ table! {
         block_reporter_votes -> Integer,
         block_reporter_votes_required -> Integer,
         moderators_online -> Integer,
+        useless_clicks -> Bigint,
     }
 }
 


### PR DESCRIPTION
I am doing this via a pull request in order to get additional opinions on the matter.
Please do leave your comments.

The original commit message:
The intentions behind this commit is to prevent the "real votes" to be
abused for "autistic-reasons". This adds an additionnal button that is
there for individuals that can't stop clicking the buttons
(I admit, they are quite difficult to resist)

This is a feature that was requested by some members of the council.