### PR TITLE
Use nightly toolchain in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest AS build
+FROM rustlang/rust:nightly AS build
 
 WORKDIR /app
 


### PR DESCRIPTION
Testauskoira is developed on the nigthly toolchain, so this is a timebomb that needs fixing.