### PR TITLE
Make deploy-to-server stage of actions depend on build success

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,7 @@ jobs:
 
   deploy:
     name: Deploy to server
+    needs: ["build-and-push-image"]
     runs-on: ubuntu-latest
     steps:
     - name: Deploy to server


### PR DESCRIPTION
It doesn't make a lot of sense to run the jobs in parallell as the deployment should be done only if the build succeeds.